### PR TITLE
Implement modular analysis workflow and progressive frontend

### DIFF
--- a/api.py
+++ b/api.py
@@ -1,6 +1,6 @@
 from fastapi import FastAPI
 from pydantic import BaseModel
-from main import executar_analise
+from main import executar_analise, consultar_software_alertas
 from fastapi.middleware.cors import CORSMiddleware
 
 app = FastAPI()
@@ -16,6 +16,11 @@ app.add_middleware(
 class AnaliseRequest(BaseModel):
     email: str
 
-@app.post("/api/analisar")
-async def analisar(req: AnaliseRequest):
+@app.post("/api/port-analysis")
+async def iniciar(req: AnaliseRequest):
     return await executar_analise(req.email)
+
+
+@app.get("/api/software-analysis/{job_id}")
+async def resultado(job_id: str):
+    return await consultar_software_alertas(job_id)

--- a/frontend/threat-detection/src/app/page.js
+++ b/frontend/threat-detection/src/app/page.js
@@ -3,7 +3,7 @@ import EmailForm from './EmailForm'
 export default function Home() {
   return (
     <main className="min-h-screen flex items-center justify-center bg-gray-100">
-      <div className="bg-white shadow-lg p-6 rounded-lg w-full max-w-xl">
+      <div className="bg-white shadow-lg p-6 rounded-lg w-full max-w-3xl">
         <h1 className="text-2xl font-bold mb-4 text-gray-800">Análise de Segurança Corporativa</h1>
         <EmailForm />
       </div>

--- a/intelligence/risk_mapper.py
+++ b/intelligence/risk_mapper.py
@@ -158,7 +158,8 @@ async def analisar_ip(ip, portas):
 
     return alertas
 
-async def avaliar_riscos(portas_por_ip):
+async def avaliar_portas(portas_por_ip):
+    """Avalia riscos com base em serviços de rede abertos."""
     alertas = []
     global softwares_detectados
     softwares_detectados = []
@@ -176,15 +177,20 @@ async def avaliar_riscos(portas_por_ip):
     for resultado in resultados:
         alertas.extend(resultado)
 
-    if softwares_detectados:
-        print("\n=== Softwares detectados para análise futura de CVEs ===")
-        for ip, porta, software in softwares_detectados:
-            print(f"{ip}:{porta} → {software}")
+    return alertas, softwares_detectados
 
-        print("\n=== Alertas de CVEs com base nos softwares detectados ===")
-        alertas_cve = await buscar_cves_para_softwares(softwares_detectados)
 
-        for alerta in alertas_cve:
-            print(f"{alerta['ip']}:{alerta['porta']} → {alerta['software']} vulnerável a {alerta['cve_id']} (CVSS: {alerta['cvss']})")
+async def avaliar_softwares(softwares):
+    """Retorna alertas de CVEs baseados nos softwares detectados."""
+    if not softwares:
+        return []
 
-    return alertas
+    alertas_cve = await buscar_cves_para_softwares(softwares)
+    return alertas_cve
+
+
+async def avaliar_riscos(portas_por_ip):
+    """Executa avaliação de portas e softwares em sequência."""
+    alertas_portas, softwares = await avaliar_portas(portas_por_ip)
+    alertas_softwares = await avaliar_softwares(softwares)
+    return alertas_portas, alertas_softwares


### PR DESCRIPTION
## Summary
- split risk mapper into `avaliar_portas` and `avaliar_softwares`
- launch software analysis in background and store results with job id
- expose `/api/port-analysis` and `/api/software-analysis/{job_id}`
- widen frontend layout and show progress boxes for both analyses
- poll backend for software results and show collapsible details

## Testing
- `npm install`
- `npm run lint` *(fails: requires interactive configuration)*
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_683f920cc2b0832d9464b439f15a95c6