### PR TITLE
Add setup files for deployment

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,7 @@
+FROM python:3.11-slim
+WORKDIR /app
+COPY requirements.txt ./
+RUN pip install --no-cache-dir -r requirements.txt
+COPY . .
+CMD ["uvicorn", "api:app", "--host", "0.0.0.0", "--port", "8000"]
+

--- a/README.md
+++ b/README.md
@@ -1,0 +1,50 @@
+# Threat Detection
+
+Este projeto possui um backend em Python (FastAPI) e um frontend em Next.js. Siga os passos abaixo para executar em qualquer servidor.
+
+## Requisitos
+
+- Python 3.11 ou superior
+- Node.js 18+ para o frontend
+- Ferramentas externas: `subfinder`, `dnsx`, `naabu` e um banco MongoDB em execução
+- Arquivo `CPE/official-cpe-dictionary_v2.3.xml` para busca de CPE (não incluído no repositório)
+
+## Instalação
+
+1. Clone o repositório e instale as dependências Python:
+   ```bash
+   pip install -r requirements.txt
+   ```
+2. Instale as dependências do frontend:
+   ```bash
+   cd frontend/threat-detection
+   npm install
+   ```
+3. (Opcional) Construa a aplicação para produção:
+   ```bash
+   npm run build
+   ```
+4. Certifique-se de que as ferramentas `subfinder`, `dnsx` e `naabu` estejam disponíveis no `PATH` do sistema e que o MongoDB esteja acessível.
+
+## Executando
+
+Para iniciar o backend durante o desenvolvimento:
+```bash
+uvicorn api:app --reload
+```
+
+O frontend pode ser iniciado em outro terminal usando:
+```bash
+npm run dev
+```
+no diretório `frontend/threat-detection`.
+
+## Docker
+
+Se preferir, é possível executar apenas o backend usando Docker:
+```bash
+docker build -t threat-detection .
+docker run -p 8000:8000 threat-detection
+```
+Certifique-se de disponibilizar as dependências externas (ferramentas e CPE XML) no container ou via volume.
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,7 @@
+fastapi
+uvicorn
+pydantic
+tldextract
+motor
+httpx
+


### PR DESCRIPTION
## Summary
- add Python requirements
- add Dockerfile for backend deployment
- document setup steps in new README

## Testing
- `pytest -q`
- `npm test --prefix frontend/threat-detection` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6841d0f345a4832d8b98cd3f1d61a05f