### PR TITLE
Add HTTP Basic auth and configurable CORS

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,3 +119,11 @@ npm run dev -- -H 0.0.0.0 -p 3000
 ```
 
 Com ambos os serviços rodando, a aplicação estará acessível para testes e uso.
+
+### Variáveis de ambiente
+
+Algumas configurações podem ser ajustadas antes de iniciar o backend:
+
+- `FRONTEND_URL`: origem permitida pelo CORS (padrão: `http://localhost:3000`)
+- `AUTH_ENABLED`: defina `0` para desativar a autenticação HTTP Basic
+- `API_USERNAME` e `API_PASSWORD`: credenciais usadas quando a autenticação está habilitada (padrão: `admin`/`password`)

--- a/api.py
+++ b/api.py
@@ -1,27 +1,53 @@
-from fastapi import FastAPI
+import os
+import secrets
+from fastapi import FastAPI, Depends, HTTPException, status
+from fastapi.security import HTTPBasic, HTTPBasicCredentials
 from pydantic import BaseModel
 from main import executar_analise, consultar_software_alertas
 from fastapi.middleware.cors import CORSMiddleware
 
 app = FastAPI()
 
+ALLOWED_ORIGIN = os.getenv("FRONTEND_URL", "http://localhost:3000")
+AUTH_ENABLED = os.getenv("AUTH_ENABLED", "1") != "0"
+API_USERNAME = os.getenv("API_USERNAME", "admin")
+API_PASSWORD = os.getenv("API_PASSWORD", "password")
+
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=["*"],  # ajuste se necessário para produção
+    allow_origins=[ALLOWED_ORIGIN],
     allow_credentials=True,
     allow_methods=["*"],
     allow_headers=["*"],
 )
 
+security = HTTPBasic()
+
+def verify(credentials: HTTPBasicCredentials = Depends(security)):
+    if not AUTH_ENABLED:
+        return
+    valid_user = secrets.compare_digest(credentials.username, API_USERNAME)
+    valid_pass = secrets.compare_digest(credentials.password, API_PASSWORD)
+    if not (valid_user and valid_pass):
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Invalid authentication credentials",
+            headers={"WWW-Authenticate": "Basic"},
+        )
+
 class AnaliseRequest(BaseModel):
     email: str
 
 @app.post("/api/port-analysis")
-async def iniciar(req: AnaliseRequest):
+async def iniciar(
+    req: AnaliseRequest, credentials: HTTPBasicCredentials = Depends(verify)
+):
     return await executar_analise(req.email)
 
 
 @app.get("/api/software-analysis/{job_id}")
-async def resultado(job_id: str):
+async def resultado(
+    job_id: str, credentials: HTTPBasicCredentials = Depends(verify)
+):
     return await consultar_software_alertas(job_id)
 


### PR DESCRIPTION
## Summary
- secure API endpoints with optional HTTP Basic auth
- restrict CORS to a single frontend origin
- document environment variables for auth configuration

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68487de4f9a4832dbd7dab65906984d6