### PR TITLE
Add optional HTTPS support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,5 +3,6 @@ WORKDIR /app
 COPY requirements.txt ./
 RUN pip install --no-cache-dir -r requirements.txt
 COPY . .
-CMD ["uvicorn", "api:app", "--host", "0.0.0.0", "--port", "8000"]
+COPY start.sh ./
+CMD ["./start.sh"]
 

--- a/README.md
+++ b/README.md
@@ -127,3 +127,21 @@ Algumas configurações podem ser ajustadas antes de iniciar o backend:
 - `FRONTEND_URL`: origem permitida pelo CORS (padrão: `http://localhost:3000`)
 - `AUTH_ENABLED`: defina `0` para desativar a autenticação HTTP Basic
 - `API_USERNAME` e `API_PASSWORD`: credenciais usadas quando a autenticação está habilitada (padrão: `admin`/`password`)
+- `SSL_CERTFILE` e `SSL_KEYFILE`: caminhos para os arquivos de certificado e chave privados que habilitam HTTPS quando presentes.
+
+### Gerar certificados autoassinados
+
+Para testes locais você pode criar um par de chaves TLS executando:
+
+```bash
+openssl req -x509 -newkey rsa:4096 -nodes -keyout server.key -out server.crt -days 365
+```
+
+Defina as variáveis de ambiente abaixo apontando para os arquivos gerados antes de iniciar o backend ou ao executar o contêiner Docker:
+
+```bash
+export SSL_KEYFILE=$(pwd)/server.key
+export SSL_CERTFILE=$(pwd)/server.crt
+```
+
+Com elas definidas, o Uvicorn servirá a API via HTTPS.

--- a/start.sh
+++ b/start.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+set -e
+
+if [ -n "$SSL_KEYFILE" ] && [ -n "$SSL_CERTFILE" ] \
+    && [ -f "$SSL_KEYFILE" ] && [ -f "$SSL_CERTFILE" ]; then
+    exec uvicorn api:app --host 0.0.0.0 --port 8000 \
+        --ssl-keyfile "$SSL_KEYFILE" --ssl-certfile "$SSL_CERTFILE"
+else
+    exec uvicorn api:app --host 0.0.0.0 --port 8000
+fi


### PR DESCRIPTION
## Summary
- document how to generate self-signed certificates
- add optional SSL startup script
- use startup script in Dockerfile

## Testing
- `python -m py_compile api.py main.py modules/subfinder.py modules/naabu.py parsers/parse_dnsx.py parsers/parse_naabu.py intelligence/risk_mapper.py intelligence/scoring.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68487ec79db0832db5a420af5ec6a6f9