### PR TITLE
Add cancelable async jobs

### DIFF
--- a/api.py
+++ b/api.py
@@ -3,7 +3,7 @@ import secrets
 from fastapi import FastAPI, Depends, HTTPException, status
 from fastapi.security import HTTPBasic, HTTPBasicCredentials
 from pydantic import BaseModel
-from main import executar_analise, consultar_software_alertas
+from main import executar_analise, consultar_software_alertas, cancelar_job
 from fastapi.middleware.cors import CORSMiddleware
 
 app = FastAPI()
@@ -50,4 +50,13 @@ async def resultado(
     job_id: str, credentials: HTTPBasicCredentials = Depends(verify)
 ):
     return await consultar_software_alertas(job_id)
+
+
+@app.post("/api/cancel/{job_id}")
+async def cancelar(
+    job_id: str, credentials: HTTPBasicCredentials = Depends(verify)
+):
+    if cancelar_job(job_id):
+        return {"status": "cancelado"}
+    raise HTTPException(status_code=404, detail="Job n\u00e3o encontrado")
 

--- a/main.py
+++ b/main.py
@@ -38,6 +38,17 @@ def limpar_pasta_data():
 jobs = {}
 
 
+def cancelar_job(job_id: str) -> bool:
+    """Cancela tarefa em andamento e remove metadados do job."""
+    job = jobs.pop(job_id, None)
+    if not job:
+        return False
+    task = job.get("task")
+    if task:
+        task.cancel()
+    return True
+
+
 async def executar_analise(email):
     """Executa a enumeração e análise, retornando apenas alertas de portas.
     O processamento de softwares continua em background e pode ser
@@ -92,7 +103,8 @@ async def executar_analise(email):
         "dominio": dominio,
         "port_score": port_score,
     }
-    asyncio.create_task(processar_softwares())
+    task = asyncio.create_task(processar_softwares())
+    jobs[job_id]["task"] = task
 
     return {
         "job_id": job_id,


### PR DESCRIPTION
## Summary
- track async tasks in backend job registry
- allow cancelling jobs via `/api/cancel/{job_id}`
- expose Cancelar button on frontend while polling

## Testing
- `python -m py_compile api.py main.py`
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684882548f34832d8050f3a73f119560