### PR TITLE
Simplify access with single password gate

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,12 +122,11 @@ Com ambos os serviços rodando, a aplicação estará acessível para testes e u
 
 ### Variáveis de ambiente
 
-Algumas configurações podem ser ajustadas antes de iniciar o backend:
+Algumas configurações podem ser ajustadas antes de iniciar o backend e o frontend:
 
 - `FRONTEND_URL`: origem permitida pelo CORS (padrão: `http://localhost:3000`)
-- `AUTH_ENABLED`: defina `0` para desativar a autenticação HTTP Basic
-- `API_USERNAME` e `API_PASSWORD`: credenciais usadas quando a autenticação está habilitada (padrão: `admin`/`password`)
 - `NEXT_PUBLIC_API_BASE`: URL do backend utilizada pelo frontend (padrão: `http://localhost:8000`)
+- `NEXT_PUBLIC_APP_PASSWORD`: senha exigida na tela inicial do frontend (padrão: `senha`)
 
 O servidor de desenvolvimento do Next.js roda apenas em HTTP. Caso deseje disponibilizar o frontend em HTTPS, utilize um proxy reverso (por exemplo, nginx) para fornecer o certificado TLS.
 

--- a/frontend/threat-detection/src/app/page.js
+++ b/frontend/threat-detection/src/app/page.js
@@ -1,6 +1,42 @@
-import EmailForm from './EmailForm'
+'use client';
+import { useState } from 'react';
+import EmailForm from './EmailForm';
+
+const APP_PASS = process.env.NEXT_PUBLIC_APP_PASSWORD || 'senha';
 
 export default function Home() {
+  const [autenticado, setAutenticado] = useState(false);
+  const [senha, setSenha] = useState('');
+
+  if (!autenticado) {
+    const handleSubmit = (e) => {
+      e.preventDefault();
+      if (senha === APP_PASS) {
+        setAutenticado(true);
+      } else {
+        alert('Senha incorreta');
+      }
+    };
+
+    return (
+      <main className="min-h-screen flex items-center justify-center bg-black text-white">
+        <form onSubmit={handleSubmit} className="bg-[#ec008c] p-4 rounded flex gap-2">
+          <input
+            type="password"
+            placeholder="Senha"
+            value={senha}
+            onChange={(e) => setSenha(e.target.value)}
+            className="p-2 rounded text-black"
+            required
+          />
+          <button type="submit" className="bg-black text-white px-4 py-2 rounded">
+            Entrar
+          </button>
+        </form>
+      </main>
+    );
+  }
+
   return (
     <main className="min-h-screen flex flex-col items-center bg-black text-white">
       <header className="w-full bg-[#ec008c] py-4 text-center">
@@ -10,5 +46,5 @@ export default function Home() {
         <EmailForm />
       </div>
     </main>
-  )
+  );
 }


### PR DESCRIPTION
## Summary
- remove Basic authentication logic from API
- update environment variables
- add a simple password screen before showing the main interface

## Testing
- `python -m py_compile api.py main.py`
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68489b8d136c832d814cd822377d8a0d