### PR TITLE
Add cancel button during port analysis

### DIFF
--- a/frontend/threat-detection/src/app/EmailForm.js
+++ b/frontend/threat-detection/src/app/EmailForm.js
@@ -16,9 +16,11 @@ export default function EmailForm() {
   const [showSoft, setShowSoft] = useState(false);
   const [showCards, setShowCards] = useState(false);
   const jobRef = useRef(null);
+  const abortRef = useRef(null);
 
   const handleSubmit = async (e) => {
     e.preventDefault();
+    abortRef.current = new AbortController();
     setShowCards(true);
     setLoadingPort(true);
     setLoadingSoft(true);
@@ -35,7 +37,8 @@ export default function EmailForm() {
         headers: {
           'Content-Type': 'application/json'
         },
-        body: JSON.stringify({ email })
+        body: JSON.stringify({ email }),
+        signal: abortRef.current.signal
       });
 
       const data = await res.json();
@@ -51,7 +54,9 @@ export default function EmailForm() {
       jobRef.current = data.job_id;
       pollSoftware(data.job_id);
     } catch (err) {
-      alert('Erro ao conectar ao backend');
+      if (err.name !== 'AbortError') {
+        alert('Erro ao conectar ao backend');
+      }
       setLoadingPort(false);
       setLoadingSoft(false);
     }
@@ -78,14 +83,21 @@ export default function EmailForm() {
 
   const cancelJob = async () => {
     const id = jobRef.current;
-    if (!id) return;
-    try {
-      await fetch(`${API_BASE}/api/cancel/${id}`, { method: 'POST' });
-    } catch (e) {
-      // ignore errors
+    if (abortRef.current) {
+      abortRef.current.abort();
+      abortRef.current = null;
+    }
+    if (id) {
+      try {
+        await fetch(`${API_BASE}/api/cancel/${id}`, { method: 'POST' });
+      } catch (e) {
+        // ignore errors
+      }
     }
     jobRef.current = null;
+    setLoadingPort(false);
     setLoadingSoft(false);
+    setShowCards(false);
   };
 
   return (
@@ -112,7 +124,16 @@ export default function EmailForm() {
           <div className="bg-[#ec008c] text-black p-4 rounded shadow">
             <h2 className="font-semibold">Port Analysis</h2>
             {loadingPort ? (
-              <p className="animate-pulse">Calculando risco...</p>
+              <>
+                <p className="animate-pulse">Calculando risco...</p>
+                <button
+                  type="button"
+                  className="underline text-sm mt-2"
+                  onClick={cancelJob}
+                >
+                  Cancelar
+                </button>
+              </>
             ) : (
               <>
                 <p className="mt-2">Score: {portScore}</p>


### PR DESCRIPTION
## Summary
- show Cancelar button while port analysis is running
- reset UI state and abort fetch when cancelling

## Testing
- `python -m py_compile main.py api.py modules/*.py parsers/*.py`
- `npm run build` *(fails: Failed to fetch fonts)*

------
https://chatgpt.com/codex/tasks/task_e_6848a3f6d98c832d86b195575bd681ae