### PR TITLE
Add cancel endpoint and move cancel button

### DIFF
--- a/api.py
+++ b/api.py
@@ -1,7 +1,12 @@
 import os
 from fastapi import FastAPI, HTTPException
 from pydantic import BaseModel
-from main import executar_analise, consultar_software_alertas, cancelar_job
+from main import (
+    executar_analise,
+    consultar_software_alertas,
+    cancelar_job,
+    cancelar_analise_atual,
+)
 from fastapi.middleware.cors import CORSMiddleware
 
 app = FastAPI()
@@ -36,4 +41,11 @@ async def cancelar(job_id: str):
     if cancelar_job(job_id):
         return {"status": "cancelado"}
     raise HTTPException(status_code=404, detail="Job n\u00e3o encontrado")
+
+
+@app.post("/api/cancel-current")
+async def cancelar_atual():
+    if cancelar_analise_atual():
+        return {"status": "cancelado"}
+    return {"status": "nenhum"}
 

--- a/modules/naabu.py
+++ b/modules/naabu.py
@@ -9,6 +9,10 @@ async def _run(cmd: list[str], timeout: int | None = None):
         proc.kill()
         await proc.communicate()
         raise subprocess.TimeoutExpired(cmd, timeout)
+    except asyncio.CancelledError:
+        proc.kill()
+        await proc.communicate()
+        raise
     if proc.returncode != 0:
         raise subprocess.CalledProcessError(proc.returncode, cmd)
 

--- a/modules/subfinder.py
+++ b/modules/subfinder.py
@@ -9,6 +9,10 @@ async def _run(cmd: list[str], timeout: int | None = None):
         proc.kill()
         await proc.communicate()
         raise subprocess.TimeoutExpired(cmd, timeout)
+    except asyncio.CancelledError:
+        proc.kill()
+        await proc.communicate()
+        raise
     if proc.returncode != 0:
         raise subprocess.CalledProcessError(proc.returncode, cmd)
 


### PR DESCRIPTION
## Summary
- add endpoint to cancel current analysis
- support aborting running port scans
- move Cancelar button next to Analisar button
- handle CancelledError in subprocess helpers

## Testing
- `python -m py_compile main.py api.py modules/*.py parsers/*.py`
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6848a3f6d98c832d86b195575bd681ae