### PR TITLE
Add static frontend option

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Threat Detection
 
-Este projeto reúne um backend em **FastAPI** e um frontend em **Next.js** para realizar varreduras de infraestrutura e correlacionar vulnerabilidades encontradas.
+Este projeto reúne um backend em **FastAPI** e um frontend.\
+Há duas opções de interface web: uma versão estática pronta para ser servida por nginx ou apache e o frontend original em **Next.js** (útil para desenvolvimento).
 
 Abaixo segue um guia comentado para preparar um ambiente Debian do zero e executar a aplicação.
 
@@ -8,7 +9,8 @@ Abaixo segue um guia comentado para preparar um ambiente Debian do zero e execut
 
 - Debian atualizado
 - Python 3.11
-- Node.js 18
+- Node.js 18 *(apenas se desejar utilizar o frontend Next.js)*
+- Servidor web (nginx ou apache) para hospedar o frontend estático
 - Go (para compilar utilitários do ProjectDiscovery)
 - MongoDB 7
 
@@ -31,7 +33,9 @@ sudo apt-get install build-essential
 sudo apt-get install libpcap-dev
 ```
 
-### 3. Instalação do Node.js 18
+### 3. (Opcional) Instalação do Node.js 18
+
+Necessário apenas se desejar utilizar o frontend em Next.js.
 
 ```bash
 curl -fsSL https://deb.nodesource.com/setup_18.x | sudo -E bash -
@@ -95,12 +99,12 @@ gunzip official-cpe-dictionary_v2.3.xml.gz
 cd ..
 ```
 
-### 10. Instalar dependências do frontend
+### 10. Configurar o frontend estático
 
-```bash
-cd frontend/threat-detection
-npm install
-```
+Não há dependências a instalar. Copie o conteúdo da pasta `frontend-static`
+para o diretório servido pelo seu servidor web (por exemplo
+`/var/www/threat-detection`). O arquivo `config.js` permite ajustar a URL do
+backend (`API_BASE`) e a senha da aplicação (`APP_PASSWORD`).
 
 ## Como executar
 
@@ -112,23 +116,20 @@ uvicorn api:app --reload
 uvicorn api:app --host 0.0.0.0 --port 8000
 ```
 
-Em outro terminal, do diretório `frontend/threat-detection`, inicie o frontend:
+Em outro terminal (ou serviço), sirva o conteúdo da pasta
+`frontend-static` em seu servidor web. Caso utilize nginx, a diretiva
+`root` deve apontar para esse diretório. Após iniciar o servidor,
+acesse a página `index.html` pelo navegador.
 
-```bash
-npm run dev
-# ou
-npm run dev -- -H 0.0.0.0 -p 3000
-```
-
-Com ambos os serviços rodando, a aplicação estará acessível para testes e uso.
+Com o backend e o servidor web ativos, a aplicação estará acessível para testes
+e uso.
 
 ### Variáveis de ambiente
 
 Algumas configurações podem ser ajustadas antes de iniciar o backend e o frontend:
 
-- `FRONTEND_URL`: origem permitida pelo CORS (padrão: `http://localhost:3000`)
-- `NEXT_PUBLIC_API_BASE`: URL do backend utilizada pelo frontend (padrão: `http://localhost:8000`)
-- `NEXT_PUBLIC_APP_PASSWORD`: senha exigida na tela inicial do frontend (padrão: `senha`)
+- `FRONTEND_URL`: origem permitida pelo CORS (padrão: `http://localhost`)
+- Edite `frontend-static/config.js` para definir `API_BASE` (URL do backend) e `APP_PASSWORD`.
 
-O servidor de desenvolvimento do Next.js roda apenas em HTTP. Caso deseje disponibilizar o frontend em HTTPS, utilize um proxy reverso (por exemplo, nginx) para fornecer o certificado TLS.
+Para disponibilizar o frontend em HTTPS, configure seu servidor web (nginx ou apache) com um certificado TLS válido, por exemplo utilizando o Let's Encrypt.
 

--- a/frontend-static/config.js
+++ b/frontend-static/config.js
@@ -1,0 +1,4 @@
+window.APP_CONFIG = {
+  API_BASE: 'http://localhost:8000',
+  APP_PASSWORD: 'senha'
+};

--- a/frontend-static/index.html
+++ b/frontend-static/index.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html lang="pt-BR">
+<head>
+  <meta charset="UTF-8">
+  <title>Threat Detection</title>
+  <link rel="stylesheet" href="styles.css">
+</head>
+<body>
+  <div id="login">
+    <form id="login-form">
+      <input type="password" id="password" placeholder="Senha" required>
+      <button type="submit">Entrar</button>
+    </form>
+  </div>
+  <div id="main" class="hidden">
+    <header>
+      <h1>ANÁLISE DE SEGURANÇA CORPORATIVA</h1>
+    </header>
+    <form id="email-form">
+      <input type="email" id="email" placeholder="usuario@empresa.com" required>
+      <button type="submit">Analisar</button>
+      <button type="button" id="cancel" class="hidden">Cancelar</button>
+    </form>
+    <div id="results"></div>
+  </div>
+  <script src="config.js"></script>
+  <script src="script.js"></script>
+</body>
+</html>

--- a/frontend-static/script.js
+++ b/frontend-static/script.js
@@ -1,0 +1,111 @@
+(function () {
+  const cfg = window.APP_CONFIG || {};
+  const API_BASE = cfg.API_BASE || '';
+  const APP_PASS = cfg.APP_PASSWORD || 'senha';
+
+  const loginDiv = document.getElementById('login');
+  const mainDiv = document.getElementById('main');
+  const loginForm = document.getElementById('login-form');
+  const passwordInput = document.getElementById('password');
+
+  const emailForm = document.getElementById('email-form');
+  const emailInput = document.getElementById('email');
+  const cancelBtn = document.getElementById('cancel');
+  const results = document.getElementById('results');
+
+  let jobId = null;
+  let abortCtrl = null;
+
+  loginForm.addEventListener('submit', function (e) {
+    e.preventDefault();
+    if (passwordInput.value === APP_PASS) {
+      loginDiv.classList.add('hidden');
+      mainDiv.classList.remove('hidden');
+    } else {
+      alert('Senha incorreta');
+    }
+  });
+
+  emailForm.addEventListener('submit', async function (e) {
+    e.preventDefault();
+    results.innerHTML = '';
+    abortCtrl = new AbortController();
+    cancelBtn.classList.remove('hidden');
+    try {
+      const res = await fetch(`${API_BASE}/api/port-analysis`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ email: emailInput.value }),
+        signal: abortCtrl.signal,
+      });
+      const data = await res.json();
+      if (data.erro) {
+        alert('Erro: ' + data.erro);
+        cancelBtn.classList.add('hidden');
+        return;
+      }
+      jobId = data.job_id;
+      renderPort(data.alertas || [], data.port_score || 0);
+      pollSoftware(jobId);
+    } catch (err) {
+      if (err.name !== 'AbortError') alert('Erro ao conectar ao backend');
+      cancelBtn.classList.add('hidden');
+    }
+  });
+
+  cancelBtn.addEventListener('click', async function () {
+    if (abortCtrl) {
+      abortCtrl.abort();
+      abortCtrl = null;
+    }
+    try { await fetch(`${API_BASE}/api/cancel-current`, { method: 'POST' }); } catch {}
+    if (jobId) {
+      try { await fetch(`${API_BASE}/api/cancel/${jobId}`, { method: 'POST' }); } catch {}
+      jobId = null;
+    }
+    cancelBtn.classList.add('hidden');
+    results.innerHTML = '';
+  });
+
+  async function pollSoftware(id) {
+    if (!id || id !== jobId) return;
+    try {
+      const res = await fetch(`${API_BASE}/api/software-analysis/${id}`);
+      const data = await res.json();
+      if (data.alertas) {
+        renderSoft(data.alertas, data.software_score || 0, data.final_score);
+        cancelBtn.classList.add('hidden');
+        jobId = null;
+      } else {
+        setTimeout(function () { pollSoftware(id); }, 2000);
+      }
+    } catch {
+      setTimeout(function () { pollSoftware(id); }, 2000);
+    }
+  }
+
+  function renderPort(alertas, score) {
+    const div = document.createElement('div');
+    div.className = 'result-card';
+    let html = `<h3>Port Analysis</h3><p>Score: ${score}</p>`;
+    if (alertas.length) {
+      html += '<ul>' + alertas.map(a => `<li><strong>${a.ip}:${a.porta}</strong> → ${a.mensagem}</li>`).join('') + '</ul>';
+    }
+    div.innerHTML = html;
+    results.appendChild(div);
+  }
+
+  function renderSoft(alertas, score, finalScore) {
+    const div = document.createElement('div');
+    div.className = 'result-card';
+    let html = `<h3>Software Analysis</h3><p>Score: ${score}</p>`;
+    if (alertas.length) {
+      html += '<ul>' + alertas.map(a => `<li><strong>${a.ip}:${a.porta}</strong> → ${a.software} vulnerável a ${a.cve_id} (CVSS ${a.cvss})</li>`).join('') + '</ul>';
+    }
+    if (finalScore !== null && finalScore !== undefined) {
+      html += `<p style="margin-top:0.5rem"><strong>Score Final: ${finalScore}</strong></p>`;
+    }
+    div.innerHTML = html;
+    results.appendChild(div);
+  }
+})();

--- a/frontend-static/styles.css
+++ b/frontend-static/styles.css
@@ -1,0 +1,61 @@
+body {
+  background: #000;
+  color: #fff;
+  font-family: Arial, Helvetica, sans-serif;
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  margin: 0;
+}
+header {
+  background: #ec008c;
+  width: 100%;
+  text-align: center;
+  padding: 1rem 0;
+  font-weight: bold;
+}
+form {
+  display: flex;
+  gap: 0.5rem;
+}
+#login-form,
+#email-form {
+  background: #ec008c;
+  padding: 1rem;
+  border-radius: 0.5rem;
+  margin-top: 2rem;
+}
+input {
+  padding: 0.5rem;
+  border-radius: 0.25rem;
+  border: none;
+}
+button {
+  background: #000;
+  color: #fff;
+  border: none;
+  padding: 0.5rem 1rem;
+  border-radius: 0.25rem;
+  cursor: pointer;
+}
+.hidden {
+  display: none;
+}
+#results {
+  width: 100%;
+  max-width: 800px;
+  margin-top: 2rem;
+}
+.result-card {
+  background: #ec008c;
+  color: #000;
+  padding: 1rem;
+  border-radius: 0.5rem;
+  margin-bottom: 1rem;
+}
+.result-card ul {
+  margin-top: 0.5rem;
+  list-style: disc;
+  padding-left: 1.5rem;
+}


### PR DESCRIPTION
## Summary
- add `frontend-static` with simple HTML/JS interface
- update README with instructions for using the static frontend instead of Next.js

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6848f29c9684832d8f32aa9585e3dd11